### PR TITLE
Bugfix: items in reverse order inside groups (ios)

### DIFF
--- a/bin/build-app-settings.js
+++ b/bin/build-app-settings.js
@@ -136,7 +136,7 @@ fs.readFile('app-settings.json', function(err, data) {
 	while (iosData.length) {
 		var src = iosData.shift();
 		if (src.type == 'group') {
-			src.items.forEach(function(s) {
+			src.items.reverse().forEach(function(s) {
 				iosData.unshift(s);
 			});
 			delete src['items'];


### PR DESCRIPTION
Hey, I noticed items inside groups were coming in the wrong order. Here's a quick fix. It comes with a 'works for me' guarantee.