### PR TITLE
Added needed line for AndroidManifest

### DIFF
--- a/bin/build-app-settings.js
+++ b/bin/build-app-settings.js
@@ -36,24 +36,24 @@ fs.readFile('app-settings.json', function(err, data) {
 	if (err) {
 		throw err;
     }
-    
+
 	var configJson = JSON.parse(data);
 
     var iosItems = mp.iosBuildItems(configJson);
-    
-	var plistXml = plist.build({ PreferenceSpecifiers: iosItems });    
-    
+
+	var plistXml = plist.build({ PreferenceSpecifiers: iosItems });
+
 	fs.exists('platforms/ios', function(exists) {
 		if (!exists) {
 			console.error('platform ios not found');
             return;
         }
-        
+
 		fs.mkdir('platforms/ios/Settings.bundle', function(e) {
 			if (e && e.code != 'EEXIST') {
 				throw e;
             }
-            
+
 			// Write settings plist
 			fs.writeFile('platforms/ios/Settings.bundle/Root.plist', plistXml, function(err) {
 				if (err) {
@@ -113,22 +113,22 @@ fs.readFile('app-settings.json', function(err, data) {
                 stringsArrays.forEach(function(stringsArray) {
                     var titlesXml = resources.node('string-array').attr({name: stringsArray.name}),
                         valuesXml = resources.node('string-array').attr({name: stringsArray.name + 'Values'});
-                    
+
                     for (var i=0, l=stringsArray.titles.length; i<l; i++) {
                         titlesXml.node('item', stringsArray.titles[i]);
                         valuesXml.node('item', stringsArray.values[i]);
                     }
-                    
+
 				});
-                
+
                 fs.writeFile('platforms/android/res/values/apppreferences_strings.xml', prefsStringsDoc.toString(), function(err) {
                     if (err) {
                         throw err;
                     }
                 });
-                
+
 			});
-			
+
 			// no error handling, sorry
 			var rs = fs.createReadStream (path.resolve (__dirname, '../src/android/AppPreferencesActivity.template'));
 			var androidPackagePath = "me.apla.cordova".replace (/\./g, '/');
@@ -137,9 +137,6 @@ fs.readFile('app-settings.json', function(err, data) {
 			ws.write ("package me.apla.cordova;\n\n");
 			ws.write ('import ' + projectConfig.packageName() + ".R;\n\n");
 			rs.pipe (ws);
-
-			console.log ('you must insert following xml node into <application> section of your Manifest:');
-			console.log ('<activity android:name="me.apla.cordova.AppPreferencesActivity"></activity>');
 		});
 	});
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,9 @@
 				<param name="android-package" value="me.apla.cordova.AppPreferences"/>
 			</feature>
 		</config-file>
-
+		<config-file target="AndroidManifest.xml" parent="/manifest/application">
+			<activity android:name="me.apla.cordova.AppPreferencesActivity" />
+		</config-file>
 		<source-file src="src/android/AppPreferences.java" target-dir="src/me/apla/cordova" />
 	</platform>
 


### PR DESCRIPTION
To avoid to ask the developer to add a specific line to the AndroidManifest.xml file we could just add it from the plugin itself.

Makes it easier when projects are fully generated from the "cordova prepare" command.