### PR TITLE
Add OS X Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ suitePrefs.store (...);
 
 Platforms
 ---
-1. Native execution on iOS using `NSUserDefaults`
+1. Native execution on iOS / OSX using `NSUserDefaults`
 1. Native execution on Android using `android.content.SharedPreferences`
 1. Native execution on Windows Phone using `IsolatedStorageSettings.ApplicationSettings`
 1. Native execution on Windows 8 using `IsolatedStorageSettings.ApplicationSettings`
@@ -98,10 +98,10 @@ Platforms
 
 Notes
 ---
-1. iOS, Android and Windows Phone basic values (`string`, `number`, `boolean`) are stored using typed fields.
+1. iOS, OSX, Android and Windows Phone basic values (`string`, `number`, `boolean`) are stored using typed fields.
 1. Complex values, such as arrays and objects, are always stored using JSON notation.
 1. Dictionaries are supported on iOS and Windows 8 only, so on other platforms instead of using the real dictionary a composite key will be written like `<dict>.<key>`
-1. On iOS dictionaries just a key, so appPrefs.store ('dict', 'key', value) and appPrefs.store ('dict', {'key': value}) have same meaning (but different result).
+1. On iOS/OSX dictionaries just a key, so appPrefs.store ('dict', 'key', value) and appPrefs.store ('dict', {'key': value}) have same meaning (but different result).
 
 Tests
 ---

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "cordova-plugin-app-preferences",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Application preferences plugin and preference pane generator",
   "cordova": {
 	"id": "cordova-plugin-app-preferences",
 	"platforms": [
 	  "android",
 	  "ios",
+	  "osx",
 	  "wp7",
 	  "wp8",
 	  "windows8",
@@ -27,6 +28,7 @@
 	"ecosystem:cordova",
 	"cordova-android",
 	"cordova-ios",
+	"cordova-osx",
 	"cordova-wp7",
 	"cordova-wp8",
 	"cordova-windows",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
 	id="cordova-plugin-app-preferences"
-	version="0.7.1">
+	version="0.7.2">
 
 	<name>AppPreferences</name>
 	<description>Application preferences plugin and preference pane generator</description>
@@ -38,6 +38,19 @@
 
 		<header-file src="src/ios/AppPreferences.h" />
 		<source-file src="src/ios/AppPreferences.m" />
+
+	</platform>
+
+	<!-- osx -->
+	<platform name="osx">
+		<config-file target="config.xml" parent="/*">
+			<feature name="AppPreferences">
+				<param name="ios-package" value="AppPreferences"/>
+			</feature>
+		</config-file>
+
+		<header-file src="src/osx/AppPreferences.h" />
+		<source-file src="src/osx/AppPreferences.m" />
 
 	</platform>
 

--- a/src/osx/AppPreferences.h
+++ b/src/osx/AppPreferences.h
@@ -1,0 +1,29 @@
+//
+//  AppPreferences.h
+//
+//
+//  Created by Tue Topholm on 31/01/11.
+//  Copyright 2011 Sugee. All rights reserved.
+//
+//  Modified by Ivan Baktsheev, 2012-2015
+//  Modified by Tobias Bocanegra, 2015
+//
+
+#import <Foundation/Foundation.h>
+
+#import <Cordova/CDVInvokedUrlCommand.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface AppPreferences : CDVPlugin
+
+- (void)defaultsChanged:(NSNotification *)notification;
+- (void)watch:(CDVInvokedUrlCommand*)command;
+- (void)fetch:(CDVInvokedUrlCommand*)command;
+- (void)remove:(CDVInvokedUrlCommand*)command;
+- (void)clearAll:(CDVInvokedUrlCommand*)command;
+- (void)show:(CDVInvokedUrlCommand*)command;
+- (void)store:(CDVInvokedUrlCommand*)command;
+- (NSString*)getSettingFromBundle:(NSString*)settingsName;
+
+
+@end

--- a/src/osx/AppPreferences.m
+++ b/src/osx/AppPreferences.m
@@ -1,0 +1,331 @@
+//
+//  AppPreferences.m
+//
+//
+//  Created by Tue Topholm on 31/01/11.
+//  Copyright 2011 Sugee. All rights reserved.
+//
+//  Modified by Ivan Baktsheev, 2012-2015
+//  Modified by Tobias Bocanegra, 2015
+//
+// THIS HAVEN'T BEEN TESTED WITH CHILD PANELS YET.
+
+#import "AppPreferences.h"
+
+@implementation AppPreferences
+
+- (void)pluginInitialize
+{
+
+}
+
+- (void)defaultsChanged:(NSNotification *)notification {
+
+	NSString * jsCallBack = [NSString stringWithFormat:@"cordova.fireDocumentEvent('preferencesChanged');"];
+	[self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
+}
+
+
+
+- (void)watch:(CDVInvokedUrlCommand*)command
+{
+
+	__block CDVPluginResult* result = nil;
+
+	NSNumber *option = command.arguments[0];
+	bool watchChanges = true;
+	if (option) {
+		watchChanges = [option boolValue];
+	}
+
+	if (watchChanges) {
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged) name:NSUserDefaultsDidChangeNotification object:nil];
+	} else {
+		[[NSNotificationCenter defaultCenter] removeObserver:self];
+	}
+
+	[self.commandDelegate runInBackground:^{
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+	}];
+}
+
+
+
+- (void)fetch:(CDVInvokedUrlCommand*)command
+{
+
+	__block CDVPluginResult* result = nil;
+
+	NSDictionary* options = command.arguments[0];
+
+	if (!options) {
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no options given"];
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+		return;
+	}
+
+	NSString *settingsDict = options[@"dict"];
+	NSString *settingsName = options[@"key"];
+	NSString *suiteName    = options[@"iosSuiteName"];
+
+	[self.commandDelegate runInBackground:^{
+
+	NSUserDefaults *defaults;
+
+	if (suiteName != nil) {
+		defaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+	} else {
+		defaults = [NSUserDefaults standardUserDefaults];
+	}
+
+
+	id target = defaults;
+
+	// NSMutableDictionary *mutable = [[dict mutableCopy] autorelease];
+	// NSDictionary *dict = [[mutable copy] autorelease];
+
+	@try {
+
+		NSString *returnVar;
+		id settingsValue = nil;
+
+		if (settingsDict) {
+			target = [defaults dictionaryForKey:settingsDict];
+			if (target == nil) {
+				returnVar = nil;
+			}
+		}
+
+		if (target != nil) {
+			settingsValue = [target objectForKey:settingsName];
+		}
+
+		if (settingsValue != nil) {
+			if ([settingsValue isKindOfClass:[NSString class]]) {
+				returnVar = [NSString stringWithFormat:@"\"%@\"", (NSString*)settingsValue];
+			} else if ([settingsValue isKindOfClass:[NSNumber class]]) {
+				if ((NSNumber*)settingsValue == (void*)kCFBooleanFalse || (NSNumber*)settingsValue == (void*)kCFBooleanTrue) {
+					// const char * x = [(NSNumber*)settingsValue objCType];
+					// NSLog(@"boolean %@", [(NSNumber*)settingsValue boolValue] == NO ? @"false" : @"true");
+					returnVar = [NSString stringWithFormat:@"%@", [(NSNumber*)settingsValue boolValue] ? @"true": @"false"];
+				} else {
+					// TODO: int, float
+					// NSLog(@"number");
+					returnVar = [NSString stringWithFormat:@"%@", (NSNumber*)settingsValue];
+				}
+
+			} else if ([settingsValue isKindOfClass:[NSData class]]) { // NSData
+				returnVar = [[NSString alloc] initWithData:(NSData*)settingsValue encoding:NSUTF8StringEncoding];
+			}
+		} else {
+			// TODO: also submit dict
+			returnVar = [self getSettingFromBundle:settingsName]; //Parsing Root.plist
+
+			// if (returnVar == nil)
+			// @throw [NSException exceptionWithName:nil reason:@"Key not found" userInfo:nil];;
+		}
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:returnVar];
+
+	} @catch (NSException * e) {
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString:[e reason]];
+
+	} @finally {
+
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+	}
+	}];
+}
+
+- (void)remove:(CDVInvokedUrlCommand*)command
+{
+
+	__block CDVPluginResult* result = nil;
+
+	NSDictionary* options = command.arguments[0];
+
+	if (!options) {
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no options given"];
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+		return;
+	}
+
+	NSString *settingsDict = options[@"dict"];
+	NSString *settingsName = options[@"key"];
+	NSString *suiteName    = options[@"iosSuiteName"];
+
+	//[self.commandDelegate runInBackground:^{
+
+	NSUserDefaults *defaults;
+
+	if (suiteName != nil) {
+		defaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+	} else {
+		defaults = [NSUserDefaults standardUserDefaults];
+	}
+
+	id target = defaults;
+
+	// NSMutableDictionary *mutable = [[dict mutableCopy] autorelease];
+	// NSDictionary *dict = [[mutable copy] autorelease];
+
+	@try {
+
+		NSString *returnVar;
+
+		if (settingsDict) {
+			target = [defaults dictionaryForKey:settingsDict];
+			if (target)
+				target = [target mutableCopy];
+		}
+
+		if (target != nil) {
+			[target removeObjectForKey:settingsName];
+			if (target != defaults)
+				[defaults setObject:(NSMutableDictionary*)target forKey:settingsDict];
+			[defaults synchronize];
+		}
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:returnVar];
+
+	} @catch (NSException * e) {
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString:[e reason]];
+
+	} @finally {
+
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+	}
+	//}];
+}
+
+- (void)clearAll:(CDVInvokedUrlCommand*)command
+{
+	__block CDVPluginResult* result;
+
+	result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"not implemented"];
+
+	[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+
+}
+
+
+- (void)show:(CDVInvokedUrlCommand*)command
+{
+	__block CDVPluginResult* result;
+    NSLog(@"OSX version of this plugin does not support show() yet.");
+    result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"switching to preferences not supported"];
+	[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+
+}
+
+- (void)store:(CDVInvokedUrlCommand*)command
+{
+	__block CDVPluginResult* result;
+
+	NSDictionary* options = command.arguments[0];
+
+	if (!options) {
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"no options given"];
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+		return;
+	}
+
+	NSString *settingsDict  = options[@"dict"];
+	NSString *settingsName  = options[@"key"];
+	NSString *settingsValue = options[@"value"];
+	NSString *settingsType  = options[@"type"];
+	NSString *suiteName     = options[@"iosSuiteName"];
+
+	//	NSLog(@"%@ = %@ (%@)", settingsName, settingsValue, settingsType);
+
+	//[self.commandDelegate runInBackground:^{
+	NSUserDefaults *defaults;
+
+	if (suiteName != nil) {
+		defaults = [[NSUserDefaults alloc] initWithSuiteName:suiteName];
+	} else {
+		defaults = [NSUserDefaults standardUserDefaults];
+	}
+
+	id target = defaults;
+
+	// NSMutableDictionary *mutable = [[dict mutableCopy] autorelease];
+	// NSDictionary *dict = [[mutable copy] autorelease];
+
+	if (settingsDict) {
+		target = [[defaults dictionaryForKey:settingsDict] mutableCopy];
+		if (!target) {
+			target = [[NSMutableDictionary alloc] init];
+			#if !__has_feature(objc_arc)
+				[target autorelease];
+			#endif
+		}
+	}
+
+	NSError* error = nil;
+	id JSONObj = [NSJSONSerialization
+		JSONObjectWithData:[settingsValue dataUsingEncoding:NSUTF8StringEncoding]
+		options:NSJSONReadingAllowFragments
+		error:&error
+	];
+
+	if (error != nil) {
+		NSLog(@"NSString JSONObject error: %@", [error localizedDescription]);
+	}
+
+	@try {
+
+		if ([settingsType isEqual: @"string"] && [JSONObj isKindOfClass:[NSString class]]) {
+			[target setObject:(NSString*)JSONObj forKey:settingsName];
+		} else if ([settingsType  isEqual: @"number"] && [JSONObj isKindOfClass:[NSNumber class]]) {
+			[target setObject:(NSNumber*)JSONObj forKey:settingsName];
+			// setInteger: forKey, setFloat: forKey:
+		} else if ([settingsType  isEqual: @"boolean"]) {
+			[target setObject:JSONObj forKey:settingsName];
+		} else {
+			// data
+			[target setObject:[settingsValue dataUsingEncoding:NSUTF8StringEncoding] forKey:settingsName];
+		}
+
+		if (target != defaults)
+			[defaults setObject:(NSMutableDictionary*)target forKey:settingsDict];
+		[defaults synchronize];
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+
+	} @catch (NSException * e) {
+
+		result = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT messageAsString:[e reason]];
+
+	} @finally {
+
+		[self.commandDelegate sendPluginResult:result callbackId:[command callbackId]];
+	}
+	//}];
+}
+
+/*
+  Parsing the Root.plist for the key, because there is a bug/feature in Settings.bundle
+  So if the user haven't entered the Settings for the app, the default values aren't accessible through NSUserDefaults.
+*/
+
+- (NSString*)getSettingFromBundle:(NSString*)settingsName
+{
+	NSString *pathStr = [[NSBundle mainBundle] bundlePath];
+	NSString *settingsBundlePath = [pathStr stringByAppendingPathComponent:@"Settings.bundle"];
+	NSString *finalPath = [settingsBundlePath stringByAppendingPathComponent:@"Root.plist"];
+
+	NSDictionary *settingsDict = [NSDictionary dictionaryWithContentsOfFile:finalPath];
+	NSArray *prefSpecifierArray = settingsDict[@"PreferenceSpecifiers"];
+	NSDictionary *prefItem;
+	for (prefItem in prefSpecifierArray)
+	{
+		if ([prefItem[@"Key"] isEqualToString:settingsName])
+			return prefItem[@"DefaultValue"];
+	}
+	return nil;
+
+}
+@end


### PR DESCRIPTION
There is an effort of adding support for OS X as platform. see https://github.com/apache/cordova-osx.
It would be great if the app-preferences plugin could support OS X.

- This pull request provides the classes for OS X, basically copy-pasted the ones from iOS.
- The show() method is currently not available, since there is no standard way to define preferences.