### PR TITLE
Fix for #55, #57

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
 
 	<asset src="www/task/AppPreferences.js" target="task/AppPreferences.js" />
 	
-	<!-- <hook type="after_prepare" src="bin/after_prepare.js" /> -->
+	<hook type="after_prepare" src="bin/after_prepare.js" />
 	<hook type="after_plugin_add" src="bin/after_plugin_add.js" />
 	<hook type="before_plugin_rm" src="bin/before_plugin_rm.js" />
 


### PR DESCRIPTION
Corrected the path to the values xml file.

This doesn’t fix that that the AppPreferences.java is not copied over but at least let’s you build when you do copy AppPreferences.java by hand.