### PR TITLE
Add android namespace to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0"
+	xmlns:android="http://schemas.android.com/apk/res/android"
 	id="cordova-plugin-app-preferences"
 	version="0.7.3">
 


### PR DESCRIPTION
Add  android namespace to plugin.xml, because Visual Studion can't add this plugin