### PR TITLE
cordova-ios 4 compatibility and missing parameter in watch method added

### DIFF
--- a/src/ios/AppPreferences.m
+++ b/src/ios/AppPreferences.m
@@ -38,7 +38,7 @@
 	}
 
 	if (watchChanges) {
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged) name:NSUserDefaultsDidChangeNotification object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(defaultsChanged:) name:NSUserDefaultsDidChangeNotification object:nil];
 	} else {
 		[[NSNotificationCenter defaultCenter] removeObserver:self];
 	}

--- a/src/ios/AppPreferences.m
+++ b/src/ios/AppPreferences.m
@@ -21,7 +21,12 @@
 - (void)defaultsChanged:(NSNotification *)notification {
 
 	NSString * jsCallBack = [NSString stringWithFormat:@"cordova.fireDocumentEvent('preferencesChanged');"];
+
+#ifdef __CORDOVA_4_0_0
+	[self.webViewEngine evaluateJavaScript:jsCallBack completionHandler:nil];
+#else
 	[self.webView stringByEvaluatingJavaScriptFromString:jsCallBack];
+#endif
 }
 
 

--- a/www/apppreferences.js
+++ b/www/apppreferences.js
@@ -303,11 +303,14 @@ successCallback, errorCallback
  * ```
  */
 AppPreferences.prototype.watch = platform.watch || function (
-	successCallback, errorCallback
+	successCallback, errorCallback, subscribe
 ) {
+	if (typeof subscribe === "undefined") {
+		subscribe = true;
+	}
 
 	var nativeExec = function (resolve, reject) {
-		return platform.nativeExec (resolve, reject, "AppPreferences", "watch", []);
+		return platform.nativeExec (resolve, reject, "AppPreferences", "watch", [subscribe]);
 	}
 
 	nativeExec (successCallback, errorCallback);


### PR DESCRIPTION
Hi,

with these changes the plugin is now compatible with cordova-ios 4 (where some breaking changes were introduced).

Also the parameter "subscribe" was missing in the watch method (now added with default "true"). The empty array made the app crash when calling the method.

Cheers,
Thomas