### PR TITLE
Fix to issue 82(cordova-plugin-app-preferences.platform already defined)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -87,14 +87,14 @@
 
 	<!-- windows8 -->
 	<platform name="windows8">
-		<js-module src="src/windows8/platform.js" name="platform">
+		<js-module src="src/windows8/platform.js" name="platform.w8">
 			<merges target="" />
 		</js-module>
 	</platform>
 
 	<!-- windows universal platform -->
 	<platform name="windows">
-		<js-module src="src/windows8/platform.js" name="platform">
+		<js-module src="src/windows8/platform.js" name="platform.windows">
 			<merges target="" />
 		</js-module>
 	</platform>


### PR DESCRIPTION
Fixing issue 82, where the following error was showing on windows apps:
0x800a139e - JavaScript runtime error: module cordova-plugin-app-preferences.platform already defined

Basically, on lines 90 and 97 you have something like this:

`90: <js-module src="src/windows8/platform.js" name="platform">`
`97: <js-module src="src/windows8/platform.js" name="platform">`

The problem is that, as you can see, the name "platform" is being used. And later, during the cordova_plugins.js generation, it turns out that this name is already taken by the main platform agnostic javascript:

Platform agnostic one(plugins/cordova-plugin-app-preferences/src/platform.js):
```
    {
        "file": "plugins/cordova-plugin-app-preferences/src/platform.js",
        "id": "cordova-plugin-app-preferences.platform",
        "pluginId": "cordova-plugin-app-preferences"
    },
```

Platform specific one(plugins/cordova-plugin-app-preferences/src/windows8/platform.js):
```
  {
        "file": "plugins/cordova-plugin-app-preferences/src/windows8/platform.js",
        "id": "cordova-plugin-app-preferences.platform",
        "pluginId": "cordova-plugin-app-preferences",
        "merges": [
            ""
        ]
    },
```

That triggered the error!

With that in mind, I got it fixed, at least temporarily, by changing my plugin.xml to something like this:

`90: <js-module src="src/windows8/platform.js" name="platform.w8">`
`97: <js-module src="src/windows8/platform.js" name="platform.windows">`

Once I have done that, the cordova_plugins.js was generated without the duplication!!!

Platform agnostic one(plugins/cordova-plugin-app-preferences/src/platform.js):
```
    {
        "file": "plugins/cordova-plugin-app-preferences/src/platform.js",
        "id": "cordova-plugin-app-preferences.platform",
        "pluginId": "cordova-plugin-app-preferences"
    },
```

Platform specific one(plugins/cordova-plugin-app-preferences/src/windows8/platform.js):
```
  {
        "file": "plugins/cordova-plugin-app-preferences/src/windows8/platform.js",
        "id": "cordova-plugin-app-preferences.platform.windows",
        "pluginId": "cordova-plugin-app-preferences",
        "merges": [
            ""
        ]
    },
```