### PR TITLE
adds support for 'read only' text fields on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ if it came from previous version of plugin.
 * combo
 * switch
 * textfield
+* title (a read-only textfield)
 
 ### Supported controls for Android:
 

--- a/bin/lib/mappings.js
+++ b/bin/lib/mappings.js
@@ -134,7 +134,7 @@ module.exports = {
 		// title is currently supported on iOS only
 		ios: "PSTitleValueSpecifier",
 		// android: "EditTextPreference",
-		// "read only" on Android requires android:editable="false"
+		// "read only" on Android requires the android:editable="false" attribute be added somehow
 		// see: http://stackoverflow.com/questions/6384004/make-edittext-readonly
 		types: "string",
 		required: ["title", "key", "default"],

--- a/bin/lib/mappings.js
+++ b/bin/lib/mappings.js
@@ -130,11 +130,18 @@ module.exports = {
 		//MinimumValue
 		//MaximumValue
 	},
-	titleNotSupported: {
-		// please use group for this, ios only
-		// TODO: probably it is good idea to add title automatically:
-		// 1. if you want to show wide text input without title
-		// 2. for a slider
-		// 3. to simulate android summary for fields
+	title: {
+		// title is currently supported on iOS only
+		ios: "PSTitleValueSpecifier",
+		// android: "EditTextPreference",
+		// "read only" on Android requires android:editable="false"
+		// see: http://stackoverflow.com/questions/6384004/make-edittext-readonly
+		types: "string",
+		required: ["title", "key", "default"],
+		attrs: {
+			key:     commonMappings.key,
+			title:   commonMappings.title,
+			default: commonMappings.default,
+		}
 	}
 };


### PR DESCRIPTION
Adds support for 'read only' text field settings on iOS.

Adds comments on how the same might be added for Android (I have no way to test it).

As discussed in https://github.com/apla/me.apla.cordova.app-preferences/issues/106.