### PR TITLE
Add description to textfield

### DIFF
--- a/bin/lib/mappings.js
+++ b/bin/lib/mappings.js
@@ -4,7 +4,7 @@
  *
  */
 'use strict';
-	
+
 var commonMappings = {
 	title: {
 		ios: "Title",
@@ -98,6 +98,7 @@ module.exports = {
 		types: "string",
 		required: ["key"],
 		attrs: {
+			description: commonMappings.description,
 			keyboard: {
 				android: "@android:inputType",
 				ios: "KeyboardType",


### PR DESCRIPTION
The `mappings.js` file does not support a `description` attribute on `textfield`s, even though Android itself does support this. Add it.