### PR TITLE
Added support for Cordova 9.0.0

### DIFF
--- a/bin/after_plugin_install.js
+++ b/bin/after_plugin_install.js
@@ -1,13 +1,12 @@
 'use strict';
 
 module.exports = function (context) {
-	var req = context.requireCordovaModule,
-		Q = req('q'),
-		path = req('path'),
-		fs = require("./lib/filesystem")(Q, req('fs'), path),
+	var Q = require('q'),
+		path = require('path'),
+		fs = require("./lib/filesystem")(Q, require('fs'), path),
 		settings = require("./lib/settings")(fs, path),
 		android = require("./lib/android")(context),
-		ios = require("./lib/ios")(Q, fs, path, req('plist'), req('xcode'));
+		ios = require("./lib/ios")(Q, fs, path, require('plist'), require('xcode'));
 
 	return settings.get()
 		.then(function (config) {

--- a/bin/after_prepare.js
+++ b/bin/after_prepare.js
@@ -1,19 +1,14 @@
 'use strict';
 
 module.exports = function (context) {
-	var req = context.requireCordovaModule,
-		Q = req('q'),
-		path = req('path'),
-		ET = req('elementtree'),
-		cordova = req('cordova'),
-		cordova_lib = cordova.cordova_lib,
-		cordova_lib_util = req('cordova-lib/src/cordova/util'),
-		fs = require("./lib/filesystem")(Q, req('fs'), path),
+	var Q = require('q'),
+		path = require('path'),
+		fs = require("./lib/filesystem")(Q, require('fs'), path),
 		settings = require("./lib/settings")(fs, path),
 		platforms = {};
 
 	platforms.android = require("./lib/android")(context);
-	platforms.ios = require("./lib/ios")(Q, fs, path, req('plist'), req('xcode'));
+	platforms.ios = require("./lib/ios")(Q, fs, path, require('plist'), require('xcode'));
 	// platforms.browser = require("./lib/browser")(Q, fs, path, req('plist'), req('xcode'));
 
 	return settings.get()

--- a/bin/before_plugin_install.js
+++ b/bin/before_plugin_install.js
@@ -1,9 +1,7 @@
 'use strict';
 
 module.exports = function (context) {
-  var req = context.requireCordovaModule,
-
-      path = req ('path'),
+  var path = require ('path'),
       pathParse = require ('./lib/path-parse');
 
   path.parse = path.parse || pathParse;

--- a/bin/before_plugin_uninstall.js
+++ b/bin/before_plugin_uninstall.js
@@ -1,15 +1,13 @@
 'use strict';
 
 module.exports = function (context) {
-	var req = context.requireCordovaModule,
-
-		Q = req('q'),
-		path = req('path'),
-		fs = require("./lib/filesystem")(Q, req('fs'), path),
+	var Q = require('q'),
+		path = require('path'),
+		fs = require("./lib/filesystem")(Q, require('fs'), path),
 		settings = require("./lib/settings")(fs, path),
 
 		android = require("./lib/android")(context),
-		ios = require("./lib/ios")(Q, fs, path, req('plist'), req('xcode'));
+		ios = require("./lib/ios")(Q, fs, path, require('plist'), require('xcode'));
 
 	return settings.get()
 		.then(function (config) {

--- a/bin/lib/android.js
+++ b/bin/lib/android.js
@@ -3,14 +3,12 @@ var mappings = require("./mappings"),
 
 module.exports = function (context) {
 
-	var
-		req = context ? context.requireCordovaModule : require,
-		Q = require('q'),
+	var Q = require('q'),
 		path = require('path'),
 		ET = require('elementtree'),
 		cordova_lib = require('cordova-lib'),
 		ConfigParser = cordova_lib.configparser,
-		cordova_util = req('cordova-lib/src/cordova/util'),
+		cordova_util = require('cordova-lib/src/cordova/util'),
 		fs = require("./filesystem")(Q, require('fs'), path),
 		platforms = {};
 

--- a/bin/lib/android.js
+++ b/bin/lib/android.js
@@ -5,14 +5,13 @@ module.exports = function (context) {
 
 	var
 		req = context ? context.requireCordovaModule : require,
-		Q = req('q'),
-		path = req('path'),
-		ET = req('elementtree'),
-		cordova = req('cordova'),
-		cordova_lib = cordova.cordova_lib,
+		Q = require('q'),
+		path = require('path'),
+		ET = require('elementtree'),
+		cordova_lib = require('cordova-lib'),
 		ConfigParser = cordova_lib.configparser,
 		cordova_util = req('cordova-lib/src/cordova/util'),
-		fs = require("./filesystem")(Q, req('fs'), path),
+		fs = require("./filesystem")(Q, require('fs'), path),
 		platforms = {};
 
 	// fs, path, ET, cordova_util, ConfigParser

--- a/bin/package.json
+++ b/bin/package.json
@@ -9,9 +9,10 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "cordova-lib": "^9.0.0",
+    "elementtree": "~0.1.6",
     "plist": "~1.0.1",
     "q": "~1.4.1",
-    "elementtree": "~0.1.6",
     "xcode": "~0.8.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "bin": {
     "cordova-app-preferences-generator": "bin/build-app-settings.js"
   },
+  "dependencies": {
+    "cordova-lib": "^9.0.0"
+  },
   "devDependencies": {
     "cordova": ">=5.4.1",
     "elementtree": "^0.1.6",

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "bugs": {
     "url": "https://github.com/apla/me.apla.cordova.app-preferences/issues"
   },
-  "homepage": "https://github.com/apla/me.apla.cordova.app-preferences"
+  "homepage": "https://github.com/apla/me.apla.cordova.app-preferences",
+  "dependencies": {
+    "cordova-lib": "^9.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,5 @@
   "bugs": {
     "url": "https://github.com/apla/me.apla.cordova.app-preferences/issues"
   },
-  "homepage": "https://github.com/apla/me.apla.cordova.app-preferences",
-  "dependencies": {
-    "cordova-lib": "^9.0.0"
-  }
+  "homepage": "https://github.com/apla/me.apla.cordova.app-preferences"
 }


### PR DESCRIPTION
As of Cordova 9.0.0 `requireCordovaModule` has been deprecated for non-cordova modules resulting in errors similar to the following:

> ERROR: Using "requireCordovaModule" to load non-cordova module "X" is not supported. Instead, add this module to your dependencies and use regular "require" to load it.

I've updated all the non-cordova imports referencing `requireCordovaModule` and switched them to `require`. I also added `cordova-lib` as a dependency to replace the import of `cordova`.

This has resolved the iOS build errors for my application, however I have not tested an Android build.